### PR TITLE
Adding parameter on XML for name and change before annotation to run classes in parallel

### DIFF
--- a/myTaxyTest.xml
+++ b/myTaxyTest.xml
@@ -1,14 +1,17 @@
 <!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
-<suite name="MyTaxyTest" verbose ="5" parallel="methods" thread-count="10">
+<suite name="MyTaxyTest" verbose ="5" parallel="methods" thread-count="4">
 
     <listeners>
         <listener class-name="test.utils.ExtentReportListener"></listener>
     </listeners>
 
+    <parameter name="userName"  value="Samantha"/>
+
     <test name="PostAppTest">
         <classes>
             <class name="test.testClasses.UsersTest"></class>
             <class name="test.testClasses.PostsTest"></class>
+            <class name="test.testClasses.CommentsTest"></class>
         </classes>
     </test>
 </suite>

--- a/src/test/java/test/BaseTest.java
+++ b/src/test/java/test/BaseTest.java
@@ -14,16 +14,31 @@ public class BaseTest {
     public static final Logger logger = Logger.getLogger(BaseTest.class);
     public String baseUri;
     private BaseClient apiClient;
+    private String username;
 
-    @BeforeTest(alwaysRun = true)
+    public BaseTest(){
+    }
+
+    public BaseTest(String username){
+        this.username = username;
+    }
+
+    @BeforeClass(alwaysRun = true)
     public void beforeSuite() throws Exception{
         PropertyConfigurator.configure("src/test/java/test/resources/log4j.properties");
         PropertiesManager.initializeProperties();
-        logger.info("Properties Initialized");
+        logger.info("Properties Initialized for thread "+Thread.currentThread().getId());
 
         baseUri = PropertiesManager.getProperty("baseURI");
         logger.info("Based URI = " + baseUri);
 
+    }
+
+    @AfterClass
+    public void afterMethod() {
+        //TODO
+        //Erase all created and/or rollback any changed data
+        System.out.println("After test-method. Thread id is: " + +Thread.currentThread().getId());
     }
 
     @DataProvider(name="userNames")
@@ -49,7 +64,7 @@ public class BaseTest {
 
     @DataProvider(name="postId")
     public Object[][] postIdProvider(){
-        String userName = "Samantha";
+        String userName = username;
 
         apiClient = new UsersClient(baseUri);
         apiClient.setExpectedResponseCode(200);

--- a/src/test/java/test/testClasses/CommentsTest.java
+++ b/src/test/java/test/testClasses/CommentsTest.java
@@ -1,7 +1,7 @@
 package test.testClasses;
 
-import myTaxy.apiModels.comments.CommentsByPostApi;
 import org.testng.Assert;
+import org.testng.annotations.Parameters;
 import org.testng.annotations.Test;
 import test.BaseTest;
 import test.clients.CommentsByPostIdClient;
@@ -9,6 +9,11 @@ import test.clients.CommentsByPostIdClient;
 public class CommentsTest extends BaseTest {
 
     private CommentsByPostIdClient client;
+
+    @Parameters({ "userName" })
+    public CommentsTest(String username){
+        super(username);
+    }
 
     @Test(dataProvider = "postId")
     public void getCommentsByPostId(int postId, int expectedCommentstAmount){


### PR DESCRIPTION
Test giving name by parameter to the test. Changing before annotation in order to fix parallel execution with current xml test configuration. May change on further PR depending if groups or classes re-configured on different test-class schema.