### PR TITLE
Check emails on comments

### DIFF
--- a/myTaxyTest.xml
+++ b/myTaxyTest.xml
@@ -9,8 +9,8 @@
 
     <test name="PostAppTest">
         <classes>
-            <!--<class name="test.testClasses.UsersTest"></class>
-            <class name="test.testClasses.PostsTest"></class>-->
+            <class name="test.testClasses.UsersTest"></class>
+            <class name="test.testClasses.PostsTest"></class>
             <class name="test.testClasses.CommentsTest"></class>
         </classes>
     </test>

--- a/myTaxyTest.xml
+++ b/myTaxyTest.xml
@@ -9,8 +9,8 @@
 
     <test name="PostAppTest">
         <classes>
-            <class name="test.testClasses.UsersTest"></class>
-            <class name="test.testClasses.PostsTest"></class>
+            <!--<class name="test.testClasses.UsersTest"></class>
+            <class name="test.testClasses.PostsTest"></class>-->
             <class name="test.testClasses.CommentsTest"></class>
         </classes>
     </test>

--- a/myTaxyTest.xml
+++ b/myTaxyTest.xml
@@ -1,5 +1,5 @@
 <!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
-<suite name="MyTaxyTest" verbose ="5" parallel="methods" thread-count="4">
+<suite name="MyTaxyTest" verbose ="5" parallel="classes" thread-count="10">
 
     <listeners>
         <listener class-name="test.utils.ExtentReportListener"></listener>

--- a/src/main/java/myTaxy/apiModels/BaseApi.java
+++ b/src/main/java/myTaxy/apiModels/BaseApi.java
@@ -38,6 +38,14 @@ public abstract class BaseApi {
     protected abstract void executeRequest();
     protected abstract void validateResponse();
 
+    public void resetRequest(){
+        requestSpecBuilder = new RequestSpecBuilder();
+    };
+
+    public void setBaseUri(String baseUri) {
+        this.baseUri = baseUri;
+    }
+
     public void perform(){
         createRequest();
         executeRequest();

--- a/src/test/java/test/BaseTest.java
+++ b/src/test/java/test/BaseTest.java
@@ -1,8 +1,5 @@
 package test;
 
-import org.jetbrains.annotations.NotNull;
-import org.json.JSONArray;
-import org.json.JSONObject;
 import org.testng.annotations.*;
 import org.apache.log4j.Logger;
 import org.apache.log4j.PropertyConfigurator;
@@ -113,6 +110,7 @@ public class BaseTest {
             ((CommentsByPostIdClient)apiClient).setPostId(postId);
             apiClient.getApiRun();
             commentsOnAllPost.addAll(apiClient.getApiResponseAsJsonArray().toList());
+            apiClient.resetRequest();
         }
 
         return JsonUtilities.getIterableFromList(commentsOnAllPost).iterator();

--- a/src/test/java/test/BaseTest.java
+++ b/src/test/java/test/BaseTest.java
@@ -2,6 +2,7 @@ package test;
 
 import org.jetbrains.annotations.NotNull;
 import org.json.JSONArray;
+import org.json.JSONObject;
 import org.testng.annotations.*;
 import org.apache.log4j.Logger;
 import org.apache.log4j.PropertyConfigurator;
@@ -106,14 +107,14 @@ public class BaseTest {
 
         apiClient = new CommentsByPostIdClient(baseUri);
         apiClient.setExpectedResponseCode(200);
-        List<Integer> commentsIdOnAllPost = new ArrayList<Integer>();
+        List<Object> commentsOnAllPost = new ArrayList<Object>();
 
         for (Integer postId: postsByUser) {
             ((CommentsByPostIdClient)apiClient).setPostId(postId);
             apiClient.getApiRun();
-            commentsIdOnAllPost.addAll(((CommentsByPostIdClient)apiClient).getListOfCommentsId());
+            commentsOnAllPost.addAll(apiClient.getApiResponseAsJsonArray().toList());
         }
 
-        return JsonUtilities.getIterableFromList(commentsIdOnAllPost).iterator();
+        return JsonUtilities.getIterableFromList(commentsOnAllPost).iterator();
     }
 }

--- a/src/test/java/test/BaseTest.java
+++ b/src/test/java/test/BaseTest.java
@@ -1,18 +1,18 @@
 package test;
 
+import org.jetbrains.annotations.NotNull;
 import org.json.JSONArray;
 import org.testng.annotations.*;
 import org.apache.log4j.Logger;
 import org.apache.log4j.PropertyConfigurator;
 import test.clients.BaseClient;
+import test.clients.CommentsByPostIdClient;
 import test.clients.PostByUserClient;
 import test.clients.UsersClient;
 import test.utils.JsonUtilities;
 import test.utils.PropertiesManager;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Iterator;
+import java.util.*;
 
 public class BaseTest {
 
@@ -87,7 +87,7 @@ public class BaseTest {
         };
     }
 
-    @DataProvider(name="userCommentsOnPosts")
+    @DataProvider(name="commentsOnUsersPosts")
     public Iterator<Object[]> getCommentsOnUserPosts(){
         String userName = username;
 
@@ -102,10 +102,18 @@ public class BaseTest {
         ((PostByUserClient)apiClient).setUserId(userId);
         apiClient.getApiRun();
 
-        JSONArray postByUser = apiClient.getApiResponseAsJsonArray();
+        List<Integer> postsByUser = ((PostByUserClient)apiClient).getListOfPostId();
 
-        Collection<Object[]> listOfPostId = new ArrayList<Object[]>();
-        JsonUtilities.getListOfIntegerValuesFromList("id", postByUser).forEach(item -> listOfPostId.add(new Object[]{item}));
-        return listOfPostId.iterator();
+        apiClient = new CommentsByPostIdClient(baseUri);
+        apiClient.setExpectedResponseCode(200);
+        List<Integer> commentsIdOnAllPost = new ArrayList<Integer>();
+
+        for (Integer postId: postsByUser) {
+            ((CommentsByPostIdClient)apiClient).setPostId(postId);
+            apiClient.getApiRun();
+            commentsIdOnAllPost.addAll(((CommentsByPostIdClient)apiClient).getListOfCommentsId());
+        }
+
+        return JsonUtilities.getIterableFromList(commentsIdOnAllPost).iterator();
     }
 }

--- a/src/test/java/test/clients/BaseClient.java
+++ b/src/test/java/test/clients/BaseClient.java
@@ -18,6 +18,10 @@ public abstract class BaseClient {
 
     public abstract void getApiRun();
 
+    public void resetRequest(){
+        apiClient.resetRequest();
+    }
+
     public String getApiResponseAsString() {
         return apiClient.getApiResponse().asString();
     }

--- a/src/test/java/test/clients/CommentsByPostIdClient.java
+++ b/src/test/java/test/clients/CommentsByPostIdClient.java
@@ -1,6 +1,9 @@
 package test.clients;
 
 import myTaxy.apiModels.comments.CommentsByPostApi;
+import test.utils.JsonUtilities;
+
+import java.util.List;
 
 public class CommentsByPostIdClient extends BaseClient {
 
@@ -25,5 +28,9 @@ public class CommentsByPostIdClient extends BaseClient {
     @Override
     public String toString() {
         return "Client for API: "+((CommentsByPostApi) apiClient).toString();
+    }
+
+    public List<Integer> getListOfCommentsId(){
+        return JsonUtilities.getListOfIntegerValuesFromList("id", this.getApiResponseAsJsonArray());
     }
 }

--- a/src/test/java/test/clients/CommentsByPostIdClient.java
+++ b/src/test/java/test/clients/CommentsByPostIdClient.java
@@ -1,6 +1,7 @@
 package test.clients;
 
 import myTaxy.apiModels.comments.CommentsByPostApi;
+import org.json.JSONObject;
 import test.utils.JsonUtilities;
 
 import java.util.List;

--- a/src/test/java/test/testClasses/CommentsTest.java
+++ b/src/test/java/test/testClasses/CommentsTest.java
@@ -5,6 +5,9 @@ import org.testng.annotations.Parameters;
 import org.testng.annotations.Test;
 import test.BaseTest;
 import test.clients.CommentsByPostIdClient;
+import test.utils.VerificationMethods;
+
+import java.util.HashMap;
 
 public class CommentsTest extends BaseTest {
 
@@ -15,7 +18,7 @@ public class CommentsTest extends BaseTest {
         super(username);
     }
 
-    /*@Test(dataProvider = "postId")
+    @Test(dataProvider = "postId")
     public void getCommentsByPostId(int postId, int expectedCommentstAmount){
         logger.info("Executing " + "getCommentsByPostId " + "URI " + baseUri);
         client = new CommentsByPostIdClient(baseUri);
@@ -32,14 +35,15 @@ public class CommentsTest extends BaseTest {
         logger.info("Comments done by users: " +commentsAmount + ", for Post Id "+postId);
 
         Assert.assertEquals(commentsAmount, expectedCommentstAmount, "Amount of comments found is not the expected");
-    }*/
+    }
 
     @Test(dataProvider = "commentsOnUsersPosts")
     public void checkEmailFormat(Object comment){
         logger.info("Executing " + "checkEmailFormat " + "URI " + baseUri);
-        logger.info("Comment id " + comment.toString());
+        logger.info("Comment id " + ((HashMap) comment).get("id").toString());
 
-
+        logger.info("Checking email format " + ((HashMap) comment).get("email"));
+        Assert.assertTrue(VerificationMethods.checkEmailFormat((((HashMap) comment).get("email")).toString()));
     }
 
 }

--- a/src/test/java/test/testClasses/CommentsTest.java
+++ b/src/test/java/test/testClasses/CommentsTest.java
@@ -34,7 +34,7 @@ public class CommentsTest extends BaseTest {
         Assert.assertEquals(commentsAmount, expectedCommentstAmount, "Amount of comments found is not the expected");
     }
 
-    @Test(dataProvider = "userCommentsOnPosts")
+    @Test(dataProvider = "commentsOnUsersPosts")
     public void checkEmailFormat(int commentId){
         logger.info("Executing " + "checkEmailFormat " + "URI " + baseUri);
 

--- a/src/test/java/test/testClasses/CommentsTest.java
+++ b/src/test/java/test/testClasses/CommentsTest.java
@@ -15,7 +15,7 @@ public class CommentsTest extends BaseTest {
         super(username);
     }
 
-    @Test(dataProvider = "postId")
+    /*@Test(dataProvider = "postId")
     public void getCommentsByPostId(int postId, int expectedCommentstAmount){
         logger.info("Executing " + "getCommentsByPostId " + "URI " + baseUri);
         client = new CommentsByPostIdClient(baseUri);
@@ -32,14 +32,14 @@ public class CommentsTest extends BaseTest {
         logger.info("Comments done by users: " +commentsAmount + ", for Post Id "+postId);
 
         Assert.assertEquals(commentsAmount, expectedCommentstAmount, "Amount of comments found is not the expected");
-    }
+    }*/
 
     @Test(dataProvider = "commentsOnUsersPosts")
-    public void checkEmailFormat(int commentId){
+    public void checkEmailFormat(Object comment){
         logger.info("Executing " + "checkEmailFormat " + "URI " + baseUri);
+        logger.info("Comment id " + comment.toString());
 
-        logger.info("Comment id " + commentId);
-        Assert.assertTrue(true);
+
     }
 
 }

--- a/src/test/java/test/utils/JsonUtilities.java
+++ b/src/test/java/test/utils/JsonUtilities.java
@@ -1,5 +1,6 @@
 package test.utils;
 
+import com.sun.codemodel.internal.JArray;
 import org.jetbrains.annotations.NotNull;
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -30,6 +31,12 @@ public class JsonUtilities {
                 return userList.getJSONObject(i);
         }
         return null;
+    }
+
+    public static Collection<Object[]> getIterableFromList(List list){
+        Collection<Object[]> objList = new ArrayList<Object[]>();
+        list.forEach(item -> objList.add(new Object[]{item}));
+        return objList;
     }
 
     private static boolean compareObjectByParameter(String parameterName, String parameterValue, JSONObject obj){

--- a/src/test/java/test/utils/VerificationMethods.java
+++ b/src/test/java/test/utils/VerificationMethods.java
@@ -1,0 +1,17 @@
+package test.utils;
+
+import javax.mail.internet.AddressException;
+import javax.mail.internet.InternetAddress;
+
+public class VerificationMethods {
+
+    public static boolean checkEmailFormat(String email){
+        try {
+            InternetAddress emailAddr = new InternetAddress(email);
+            emailAddr.validate();
+            return true;
+        } catch (AddressException ex) {
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
"Phase 1 completed!!. Check email on comments done based on other services responses. Adding a class in the utils package to handle all validation related methods which should always respond a boolean based on the check on the given parameter."

Doing data provider "commentsOnUsersPosts" I noticed that resource "/comments?postId=#" allowed multiple query parameters. I could have used it to prepare a request like "/comments?postId=#&postId=#" but I think this could be an issue and service should allow only 1 parameter. Anyway that could allow me to go to server and consume service only once with all parameters but I would rather talk first with dev team about it.

Next step would be to add other type of test. Like Post test with complete info and with partial info, SQL injection, and others that I may think about


